### PR TITLE
Normalize REST method capitalization

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -77,8 +77,11 @@ function merge(obj1, obj2) {
 
 function send() {
 	return async (request) => {
-		const {url, headers, ...rest} = request
-		const response = await fetch(url, {...rest, headers: new Headers(headers)})
+		const {url, headers, method, ...rest} = request
+		const response = await fetch(url, {
+			...rest,
+			method: method.toUpperCase(),
+			headers: new Headers(headers)})
 		if (!response.ok) throw new RequestError(response)
 		return response
 	}

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -25,7 +25,7 @@ describe(`a basic client`, function() {
 		const [url, options] = fetchMock.calls()[0]
 		expect(url).to.equal(`https://api.test.com/v1/account?test=data`)
 		expect(options).to.deep.equal({
-			method: `get`,
+			method: `GET`,
 			headers: new Headers({}),
 			body: undefined,
 		})
@@ -41,7 +41,7 @@ describe(`a basic client`, function() {
 		const [url, options] = fetchMock.calls()[0]
 		expect(url).to.equal(`https://api.test.com/v1/account`)
 		expect(options).to.deep.equal({
-			method: `post`,
+			method: `POST`,
 			headers: new Headers({}),
 			body: `{"test":"data"}`,
 		})
@@ -57,7 +57,7 @@ describe(`a basic client`, function() {
 		const [url, options] = fetchMock.calls()[0]
 		expect(url).to.equal(`https://api.test.com/v1/account`)
 		expect(options).to.deep.equal({
-			method: `put`,
+			method: `PUT`,
 			headers: new Headers({}),
 			body: `{"test":"data"}`,
 		})
@@ -73,7 +73,7 @@ describe(`a basic client`, function() {
 		const [url, options] = fetchMock.calls()[0]
 		expect(url).to.equal(`https://api.test.com/v1/account`)
 		expect(options).to.deep.equal({
-			method: `patch`,
+			method: `PATCH`,
 			headers: new Headers({}),
 			body: `{"test":"data"}`,
 		})
@@ -89,7 +89,7 @@ describe(`a basic client`, function() {
 		const [url, options] = fetchMock.calls()[0]
 		expect(url).to.equal(`https://api.test.com/v1/account?test=data`)
 		expect(options).to.deep.equal({
-			method: `delete`,
+			method: `DELETE`,
 			headers: new Headers({}),
 			body: undefined,
 		})

--- a/test/middlewares-test.js
+++ b/test/middlewares-test.js
@@ -22,7 +22,7 @@ describe(`using middlewares with the client`, function() {
 		const [url, options] = fetchMock.calls()[0]
 		expect(url).to.equal(`https://api.test.com/v1/account?test=data`)
 		expect(options).to.deep.equal({
-			method: `get`,
+			method: `GET`,
 			headers: new Headers({
 				'Content-Type': `application/json`,
 				Accept: `application/json`
@@ -42,7 +42,7 @@ describe(`using middlewares with the client`, function() {
 		const [url, options] = fetchMock.calls()[0]
 		expect(url).to.equal(`https://api.test.com/v1/account?test=data`)
 		expect(options).to.deep.equal({
-			method: `get`,
+			method: `GET`,
 			headers: new Headers({
 				'Content-Type': `application/json`,
 				Accept: `application/json`
@@ -62,7 +62,7 @@ describe(`using middlewares with the client`, function() {
 		const [url, options] = fetchMock.calls()[0]
 		expect(url).to.equal(`https://api.test.com/v1/account?test=data`)
 		expect(options).to.deep.equal({
-			method: `get`,
+			method: `GET`,
 			headers: new Headers({
 				Accept: `text/html`
 			}),
@@ -81,7 +81,7 @@ describe(`using middlewares with the client`, function() {
 		const [url, options] = fetchMock.calls()[0]
 		expect(url).to.equal(`https://api.test.com/v1/account?test=data`)
 		expect(options).to.deep.equal({
-			method: `get`,
+			method: `GET`,
 			headers: new Headers({
 				Accept: `text/html`
 			}),
@@ -100,7 +100,7 @@ describe(`using middlewares with the client`, function() {
 
 		const [url, options] = fetchMock.calls()[0]
 		expect(url).to.equal(`https://api.test.com/v1/account`)
-		expect(options.method).to.equal(`post`)
+		expect(options.method).to.equal(`POST`)
 		expect(options.headers).to.deep.equal(new Headers({'Content-Type': `multipart/form-data`}))
 		expect(options.body._streams[0]).to.contain(`name="test"`)
 		expect(options.body._streams[1]).to.equal(`data`)
@@ -124,7 +124,7 @@ describe(`using middlewares with the client`, function() {
 		const [url1, options1] = fetchMock.calls()[0]
 		expect(url1).to.equal(`https://api.test.com/v1/login`)
 		expect(options1).to.deep.equal({
-			method: `post`,
+			method: `POST`,
 			credentials: `include`,
 			headers: new Headers({
 				Authorization: ``,
@@ -135,7 +135,7 @@ describe(`using middlewares with the client`, function() {
 		const [url2, options2] = fetchMock.calls()[1]
 		expect(url2).to.equal(`https://api.test.com/v1/account`)
 		expect(options2).to.deep.equal({
-			method: `get`,
+			method: `GET`,
 			credentials: `include`,
 			headers: new Headers({
 				Authorization: `Bearer test-token`,
@@ -161,7 +161,7 @@ describe(`using middlewares with the client`, function() {
 
 		const [url1, options1] = fetchMock.calls()[0]
 		expect(url1).to.equal(`https://api.test.com/v1/login`)
-		expect(options1.method).to.equal(`post`)
+		expect(options1.method).to.equal(`POST`)
 		expect(options1.credentials).to.equal(`include`)
 		expect(options1.headers).to.deep.equal(new Headers({
 			'Content-Type': `multipart/form-data`,
@@ -176,7 +176,7 @@ describe(`using middlewares with the client`, function() {
 		const [url2, options2] = fetchMock.calls()[1]
 		expect(url2).to.equal(`https://api.test.com/v1/account`)
 		expect(options2).to.deep.equal({
-			method: `get`,
+			method: `GET`,
 			credentials: `include`,
 			headers: new Headers({
 				'Content-Type': `application/json`,


### PR DESCRIPTION
Ran into an issue using `patch` where the REST method name doesn't automatically capitalize when making requests in the browser, causing a number of CORS issues. I've updated all request methods to capitalize by default.

🔼 🔠 