### PR TITLE
Fix: Bearer Auth `localStorage` Store

### DIFF
--- a/src/middlewares/bearer-auth.js
+++ b/src/middlewares/bearer-auth.js
@@ -7,8 +7,8 @@ const stores = {
 		write: (k, v) => document.cookie = `${k}=${v}`,
 	},
 	localstorage: {
-		read: localStorage.getItem,
-		write: localStorage.setItem,
+		read: (k) => localStorage.getItem(k),
+		write: (k, v) => localStorage.setItem(k, v),
 	},
 	memory: {
 		_store: {},


### PR DESCRIPTION
Fixed `localStorage` store methods to take arguments due to build time limitations.

🔧 🚧 🏬 